### PR TITLE
Add ModernWpfUI styles

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -1,9 +1,16 @@
-﻿<Application x:Class="NodaStack.App"
+<Application x:Class="NodaStack.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:NodaStack"
+             xmlns:ui="http://schemas.modernwpf.com/2019"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-         <local:BytesToStringConverter x:Key="BytesToStringConverter"/>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ui:ThemeResources />
+                <ui:XamlControlsResources />
+            </ResourceDictionary.MergedDictionaries>
+            <local:BytesToStringConverter x:Key="BytesToStringConverter"/>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/BackupWindow.xaml
+++ b/BackupWindow.xaml
@@ -2,13 +2,15 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:NodaStack"
+        xmlns:ui="http://schemas.modernwpf.com/2019"
         Title="Backup &amp; Import/Export - NodaStack"
         Icon="Assets/NodaStackLogo.ico"
         Width="900"
         Height="650"
         ResizeMode="CanResize"
         WindowStartupLocation="CenterOwner"
-        Background="#1E1E1E">
+        Background="#1E1E1E"
+        ui:WindowHelper.UseModernWindowStyle="True">
 
     <Window.Resources>
         <local:BytesToStringConverter x:Key="BytesToStringConverter"/>

--- a/ConfigurationWindow.xaml
+++ b/ConfigurationWindow.xaml
@@ -1,13 +1,15 @@
 <Window x:Class="NodaStack.ConfigurationWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:ui="http://schemas.modernwpf.com/2019"
         Title="NodaStack Configuration"
         Icon="Assets/NodaStackLogo.ico"
         Height="600"
         Width="800"
         ResizeMode="NoResize"
         WindowStartupLocation="CenterOwner"
-        ShowInTaskbar="False">
+        ShowInTaskbar="False"
+        ui:WindowHelper.UseModernWindowStyle="True">
 
     <Grid Margin="20">
         <Grid.RowDefinitions>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,14 +1,15 @@
-﻿<Window x:Class="NodaStack.MainWindow"
+<Window x:Class="NodaStack.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:ui="http://schemas.modernwpf.com/2019"
         Title="NodaStack"
         Icon="Assets/NodaStackLogo.ico"
         Height="600"
         Width="1000"
         ResizeMode="CanResize"
         WindowStartupLocation="CenterScreen"
-        Background="{DynamicResource BackgroundBrush}">
-
+        Background="{DynamicResource BackgroundBrush}"
+        ui:WindowHelper.UseModernWindowStyle="True">
         <Window.InputBindings>
                 <KeyBinding Key="M"
                             Modifiers="Ctrl"
@@ -75,7 +76,8 @@
                                         Height="30"
                                         Margin="0,0,5,0"
                                         Click="Monitoring_Click"
-                                        ToolTip="Ctrl+M">
+                                        ToolTip="Ctrl+M"
+                                        Style="{StaticResource AccentButtonStyle}">
                                         <StackPanel Orientation="Horizontal">
                                                 <TextBlock Text="📊"
                                                            FontSize="14"
@@ -87,7 +89,8 @@
                                         Width="120"
                                         Height="30"
                                         Click="Configuration_Click"
-                                        ToolTip="Ctrl+,">
+                                        ToolTip="Ctrl+,"
+                                        Style="{StaticResource AccentButtonStyle}">
                                         <StackPanel Orientation="Horizontal">
                                                 <TextBlock Text="⚙️"
                                                            FontSize="14"
@@ -100,7 +103,8 @@
                                         Height="30"
                                         Margin="5,0,0,0"
                                         Click="BackupMenuItem_Click"
-                                        ToolTip="Ctrl+B">
+                                        ToolTip="Ctrl+B"
+                                        Style="{StaticResource AccentButtonStyle}">
                                         <StackPanel Orientation="Horizontal">
                                                 <TextBlock Text="💾"
                                                            FontSize="14"
@@ -142,7 +146,8 @@
                                                         Height="35"
                                                         Margin="0,0,0,5"
                                                         Click="StartApache_Click"
-                                                        ToolTip="Ctrl+1">
+                                                        ToolTip="Ctrl+1"
+                                                        Style="{StaticResource AccentButtonStyle}">
                                                         <StackPanel Orientation="Horizontal">
                                                                 <TextBlock Text="▶️"
                                                                            FontSize="12"
@@ -200,7 +205,8 @@
                                                         Height="35"
                                                         Margin="0,0,0,5"
                                                         Click="StartPHP_Click"
-                                                        ToolTip="Ctrl+2">
+                                                        ToolTip="Ctrl+2"
+                                                        Style="{StaticResource AccentButtonStyle}">
                                                         <StackPanel Orientation="Horizontal">
                                                                 <TextBlock Text="▶️"
                                                                            FontSize="12"
@@ -258,7 +264,8 @@
                                                         Height="35"
                                                         Margin="0,0,0,5"
                                                         Click="StartMySQL_Click"
-                                                        ToolTip="Ctrl+3">
+                                                        ToolTip="Ctrl+3"
+                                                        Style="{StaticResource AccentButtonStyle}">
                                                         <StackPanel Orientation="Horizontal">
                                                                 <TextBlock Text="▶️"
                                                                            FontSize="12"
@@ -316,7 +323,8 @@
                                                         Height="35"
                                                         Margin="0,0,0,5"
                                                         Click="StartPhpMyAdmin_Click"
-                                                        ToolTip="Ctrl+4">
+                                                        ToolTip="Ctrl+4"
+                                                        Style="{StaticResource AccentButtonStyle}">
                                                         <StackPanel Orientation="Horizontal">
                                                                 <TextBlock Text="▶️"
                                                                            FontSize="12"
@@ -388,7 +396,8 @@
                                                         Height="25"
                                                         Margin="0,0,5,0"
                                                         Click="CreateProject_Click"
-                                                        ToolTip="Ctrl+N">
+                                                        ToolTip="Ctrl+N"
+                                                        Style="{StaticResource AccentButtonStyle}">
                                                         <StackPanel Orientation="Horizontal">
                                                                 <TextBlock Text="➕"
                                                                            FontSize="10"

--- a/MonitoringWindow.xaml
+++ b/MonitoringWindow.xaml
@@ -1,12 +1,14 @@
 <Window x:Class="NodaStack.MonitoringWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:ui="http://schemas.modernwpf.com/2019"
         Title="System Monitoring"
         Icon="Assets/NodaStackLogo.ico"
         Height="600"
         Width="800"
         ResizeMode="CanResize"
-        WindowStartupLocation="CenterOwner">
+        WindowStartupLocation="CenterOwner"
+        ui:WindowHelper.UseModernWindowStyle="True">
 
     <Grid Margin="10">
         <Grid.RowDefinitions>

--- a/NodaStack.csproj
+++ b/NodaStack.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="9.0.7" />
+    <PackageReference Include="ModernWpfUI" Version="0.9.6" />
     <ProjectReference Include="Core/NodaStack.Core.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/ThemeManager.cs
+++ b/ThemeManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Controls;
+using ModernWpf;
 
 namespace NodaStack
 {
@@ -32,6 +33,7 @@ namespace NodaStack
             try
             {
                 app.Resources.Clear();
+                ModernWpf.ThemeManager.Current.ApplicationTheme = isDark ? ApplicationTheme.Dark : ApplicationTheme.Light;
 
                 if (isDark)
                 {


### PR DESCRIPTION
## Summary
- add ModernWpfUI nuget package
- use ModernWpf theme resources and window style
- hook theme manager into ModernWpf ThemeManager
- give some buttons the AccentButton style

## Testing
- `dotnet build NodaStack.sln -c Release` *(fails: NETSDK1045)*

------
https://chatgpt.com/codex/tasks/task_e_6885004195f4832f8ae75d2ba22e47cd